### PR TITLE
Build Windows installer instead of raw tar.gz archive

### DIFF
--- a/.github/workflows/puredata.yml
+++ b/.github/workflows/puredata.yml
@@ -93,6 +93,7 @@ jobs:
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-autotools
             mingw-w64-x86_64-gettext
+            mingw-w64-x86_64-nsis
             make
             autoconf
             automake
@@ -105,17 +106,26 @@ jobs:
           ./configure CFLAGS="-O2 -DPD_VIBES_RELEASE"
           make -j$(nproc)
 
+      - name: Create app directory
+        run: |
+          cd msw
+          ./msw-app.sh --builddir .. vibes
+
+      - name: Build installer
+        run: |
+          cd msw
+          ./build-nsi.sh -o "$(pwd)" pd-vibes vibes
+
       - name: Package
         run: |
-          make DESTDIR=$(pwd)/pkg install
-          cd pkg
-          tar czf ../Pd-vibes-windows-x86_64.tar.gz .
+          cd msw
+          mv Pd-vibes.windows-installer.exe Pd-vibes-windows-x86_64-installer.exe
 
-      - name: Upload Windows artifact
+      - name: Upload Windows installer
         uses: actions/upload-artifact@v4
         with:
           name: Pd-vibes-windows-x86_64
-          path: Pd-vibes-windows-x86_64.tar.gz
+          path: msw/Pd-vibes-windows-x86_64-installer.exe
 
   # ── Create GitHub Release ──────────────────────────────────────
   release:
@@ -136,4 +146,4 @@ jobs:
           files: |
             artifacts/Pd-vibes-macos/Pd-vibes-macos.zip
             artifacts/Pd-vibes-linux-x86_64/Pd-vibes-linux-x86_64.tar.gz
-            artifacts/Pd-vibes-windows-x86_64/Pd-vibes-windows-x86_64.tar.gz
+            artifacts/Pd-vibes-windows-x86_64/Pd-vibes-windows-x86_64-installer.exe

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download the latest release for your platform from the **[Releases](../../releas
   - On first launch, macOS may warn that it "can't check the app for malicious software."
   - Right-click the app in Finder, choose **Open**, then click **Open** again to bypass this.
   - Alternatively, go to **System Settings > Privacy & Security**, scroll down to the Security section, and click **Open Anyway** next to the Pd-vibes message.
-- **Windows**: Download `Pd-vibes-windows-x86_64.tar.gz`, extract, run `bin\pd.exe`
+- **Windows**: Download `Pd-vibes-windows-x86_64-installer.exe`, run the installer, then launch Pd from the Start menu or desktop shortcut.
 
 Launch Pd-vibes. The MCP server starts automatically, and Pd-vibes will attempt to automatically register itself in your Claude Desktop configuration file.
 


### PR DESCRIPTION
Use msw-app.sh and build-nsi.sh (already in repo) to produce a proper NSIS installer with Start menu entries, file associations, and uninstaller — matching how vanilla Pd ships on Windows.